### PR TITLE
Metrics

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -361,70 +361,60 @@ INFO METRIC: <metrics-json>
 
 #### source
 
-* type - The type of the metric. Indicates how consumers of the data
-  should interpret the "value" field. Stitch currently recognizes two
-  metric types, "counter" and "timer":
+* `type` - The type of the metric. Indicates how consumers of the data
+  should interpret the "value" field. There are two types of metrics,
+  "counter" and "timer":
   
-    * counter - the value should be interpreted as a number that is added
+    * `counter` - the value should be interpreted as a number that is added
       to a cumulative or running total.
       
-    * timer - the value is the duration in seconds of some operation.
+    * `timer` - the value is the duration in seconds of some operation.
   
-* metric - The name of the metric. This should consist only of letters,
-  numbers, underscore, and dash characters.
+* `metric` - The name of the metric. This should consist only of letters,
+  numbers, underscore, and dash characters. For example,
+  `"http_request_duration"`.
 
-* value - The value of the datapoint, either an integer or a float.
+* `value` - The value of the datapoint, either an integer or a float. For
+  example, `1234` or `1.234`.
 
-* tags - Mapping of tags describing the data. 
+* `tags` - Mapping of tags describing the data. The keys can be any
+  strings consisting solely of letters, numbers, underscores, and dashes.
+  For consistency's sake, we recommend using the following tags when they
+  are relevant.
+  
+    * `endpoint` - For a Tap that pulls data from an HTTP API, this should
+      be a descriptive name for the endpoint, such as `"users"` or `"deals"`
+      or `"orders"`.
 
+    * `http_status_code` - The HTTP status code. For example, `200` or
+      `500`.
+
+    * `job_type` - For a process that we are timing, some description of
+      the type of the job. For example, if we have a Tap that does a POST
+      to an HTTP API to generate a report and then polls with a GET until
+      the report is done, we could use a job type of `"run_report"`.
     
+    * `status` - Either `"succeeded"` or `"failed"`.
 
-`source` is a short name describing the source of the data within the
-context of this Tap. You should choose a source naming structure that
-allows easy grouping.  For an HTTP service, you should not use a full
-URL. For example, for a Tap that paginates through orders by making GET
-requests to
-`http://myapi.com/customers/{cust-id}/orders?offset={offset}&limit={limit}`,
-"orders" would be a good source name.
-
-#### status
-
-A string describing the status of the operation, either "running",
-"succeeded", or "failed".
-
-#### http_status_code
-
-A Tap that pulls data directly from an HTTP service SHOULD indicate
-the HTTP status code of each request in this field.
-
-#### duration
-
-The time duration covered by this metric, in seconds. Floating point
-numbers are allowed in order to provide sub-second precision. For a
-synchronous fetch operation like an HTTP GET, this would be the duration
-of the request. For a stream of records, this should be the time since the
-previous metric was reported, NOT the time for the entire operation.
-
-#### record_count
-
-Number of records read. For a batch operation this should be the
-number of records in the batch. For a streaming operation this should
-be the number of records since the last metric was reported, NOT the
-cumulative record count for the whole operation.
-
-#### byte_count
-
-Bytes read. Like record_count, this should NOT be cumulative.
-
+  Note that for many metrics, many of those tags will _not_ be relevant.
+  
 ### Examples
 
 Here are some examples of metrics and how those metrics should be
 interpreted.
 
-#### Example 1: Successful HTTP GET
+#### Example 1: Timer for Successful HTTP GET
 
 ```
-INFO STATS: {"source": "orders", "status": "succeeded", "http_status_code": 200, "duration": 1.23, "record_count": 100, "byte_count": 12345}
+INFO STATS: {"type": "timer",\
+             "metric": "http_request_duration",\
+             "value": 1.23,\
+             "tags": {\
+               "endpoint": "orders",\
+               "http_status_code": 200,\
+               "status": "succeeded"\
+             }\
+            }
 ```
 
 > We made an HTTP request to an "orders" endpoint that took 1.23,

--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -347,25 +347,37 @@ A Tap should periodically emit structured log messages containing metrics
 about read operations.
 
 ```
-INFO STATS: <metrics-json>
+INFO METRIC: <metrics-json>
 ```
 
 `<metrics-json>` should be a JSON object where the keys are limited to the following:
 
-* source
-* status
-* http_status_code
-* duration
-* record_count
-* byte_count
-
-All fields are optional. A Tap SHOULD report whatever fields are
-meaningful for the kinds of operations it performs. A Tap SHOULD NOT
-include a field that it cannot reliably compute.
+* type
+* metric
+* value
+* tags
 
 ### Fields
 
 #### source
+
+* type - The type of the metric. Indicates how consumers of the data
+  should interpret the "value" field. Stitch currently recognizes two
+  metric types, "counter" and "timer":
+  
+    * counter - the value should be interpreted as a number that is added
+      to a cumulative or running total.
+      
+    * timer - the value is the duration in seconds of some operation.
+  
+* metric - The name of the metric. This should consist only of letters,
+  numbers, underscore, and dash characters.
+
+* value - The value of the datapoint, either an integer or a float.
+
+* tags - Mapping of tags describing the data. 
+
+    
 
 `source` is a short name describing the source of the data within the
 context of this Tap. You should choose a source naming structure that

--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -352,15 +352,6 @@ INFO METRIC: <metrics-json>
 
 `<metrics-json>` should be a JSON object where the keys are limited to the following:
 
-* type
-* metric
-* value
-* tags
-
-### Fields
-
-#### source
-
 * `type` - The type of the metric. Indicates how consumers of the data
   should interpret the "value" field. There are two types of metrics,
   "counter" and "timer":
@@ -406,50 +397,30 @@ interpreted.
 #### Example 1: Timer for Successful HTTP GET
 
 ```
-INFO STATS: {"type": "timer",\
-             "metric": "http_request_duration",\
-             "value": 1.23,\
-             "tags": {\
-               "endpoint": "orders",\
-               "http_status_code": 200,\
-               "status": "succeeded"\
-             }\
-            }
-```
-
-> We made an HTTP request to an "orders" endpoint that took 1.23,
-> succeeded with a status code of 200, and returned a body with 12345
-> bytes containing 100 records.
-
-#### Example 2: Failed HTTP GET
-
-```
-INFO STATS: {"source": "orders", "status": "failed", "http_status_code": 400, "duration": 1.23}
+INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 1.23, "tags": {"endpoint": "orders", "http_status_code": 200, "status": "succeeded"}}
 ```
 
 > We made an HTTP request to an "orders" endpoint that took 1.23 seconds
-> and failed with a status code of 400.
+> and succeeded with a status code of 200.
 
-#### Example 3: Successful streaming operation
-
-```
-INFO STATS: {"source": "orders", "status": "running", "duration": 1.2, "record_count": 100}
-INFO STATS: {"source": "orders", "status": "running", "duration": 0.9, "record_count": 100}
-INFO STATS: {"source": "orders", "status": "running", "duration": 2.3, "record_count": 100}
-INFO STATS: {"source": "orders", "status": "succeeded", "duration": 0.1, "record_count": 14}
-```
-
-We fetched a total of 314 records from an "orders" endpoint in 4.5 seconds.
-
-#### Example 4: Successful HTTP GET
+#### Example 2: Timer for Failed HTTP GET
 
 ```
-INFO STATS: {"source": "orders", "status": "succeeded", "http_status_code": 200, "duration": 1.23}
+INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 30.01, "tags": {"endpoint": "orders", "http_status_code": 500, "status": "failed"}}
 ```
 
-> We made an HTTP request that succeeded and returned an unspecified
-> number of records.
+> We made an HTTP request to an "orders" endpoint that took 30.01 seconds
+> and failed with a status code of 500.
 
-If a Tap hits a lot of different HTTP endpoints with different
-response structures, and it would be too cumbersome to discern and
-report accurate record counts, a Tap can simply omit that field.
+#### Example 3: Counter for Records
+
+```
+INFO METRIC: {"type": "counter", "metric": "record_count", "value": 100, "tags": {"endpoint: "orders"}}
+INFO METRIC: {"type": "counter", "metric": "record_count", "value": 100, "tags": {"endpoint: "orders"}}
+INFO METRIC: {"type": "counter", "metric": "record_count", "value": 100, "tags": {"endpoint: "orders"}}
+INFO METRIC: {"type": "counter", "metric": "record_count", "value": 14, "tags": {"endpoint: "orders"}}
+
+```
+
+We fetched a total of 314 records from an "orders" endpoint.
+

--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -370,7 +370,7 @@ include a field that it cannot reliably compute.
 `source` is a short name describing the source of the data within the
 context of this Tap. You should choose a source naming structure that
 allows easy grouping.  For an HTTP service, you should not use a full
-URL. For example, for a Tap thatpaginates through orders by making GET
+URL. For example, for a Tap that paginates through orders by making GET
 requests to
 `http://myapi.com/customers/{cust-id}/orders?offset={offset}&limit={limit}`,
 "orders" would be a good source name.
@@ -389,10 +389,9 @@ the HTTP status code of each request in this field.
 
 The time duration covered by this metric, in seconds. Floating point
 numbers are allowed in order to provide sub-second precision. For a
-synchronous fetch operation like an HTTP GET, this would be the
-duration of the request. For a stream of records, this should be the
-number of seconds since the previous metric was reported, NOT the
-cumulative number of seconds for the entire operation.
+synchronous fetch operation like an HTTP GET, this would be the duration
+of the request. For a stream of records, this should be the time since the
+previous metric was reported, NOT the time for the entire operation.
 
 #### record_count
 

--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -344,22 +344,22 @@ Metrics
 -------
 
 A Tap should periodically emit structured log messages containing metrics
-about read operations.
+about read operations. Consumers of the Tap logs can parse these metrics
+out of the logs for monitoring or analysis.
 
 ```
 INFO METRIC: <metrics-json>
 ```
 
-`<metrics-json>` should be a JSON object where the keys are limited to the following:
+`<metrics-json>` should be a JSON object with the following keys;
 
 * `type` - The type of the metric. Indicates how consumers of the data
-  should interpret the "value" field. There are two types of metrics,
-  "counter" and "timer":
+  should interpret the `value` field. There are two types of metrics:
   
-    * `counter` - the value should be interpreted as a number that is added
+    * `counter` - The value should be interpreted as a number that is added
       to a cumulative or running total.
       
-    * `timer` - the value is the duration in seconds of some operation.
+    * `timer` - The value is the duration in seconds of some operation.
   
 * `metric` - The name of the metric. This should consist only of letters,
   numbers, underscore, and dash characters. For example,
@@ -422,5 +422,5 @@ INFO METRIC: {"type": "counter", "metric": "record_count", "value": 14, "tags": 
 
 ```
 
-We fetched a total of 314 records from an "orders" endpoint.
+> We fetched a total of 314 records from an "orders" endpoint.
 

--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -339,3 +339,64 @@ properties of the "users" stream:
   }
 }
 ```
+
+Metrics
+-------
+
+A Tap should periodically emit structured log messages containing metrics
+about read operations.
+
+```
+INFO STATS: <metrics-json>
+```
+
+`<metrics-json>` should be a JSON object where the keys are limited to the following:
+
+* `source` Source of the data, as a string
+* `status` Either 'running', 'succeeded', or 'failed'
+* `http_status_code` The HTTP status code of the response, for HTTP requests
+* `duration` Duration of the operation in seconds
+* `record_count` Number of records fetched
+* `byte_count` Number of bytes fetched
+
+
+### Examples
+
+#### Example 1
+
+```
+INFO STATS: {"source": "orders", "status": "succeeded", "http_status_code": 200, "duration": 1.23, "record_count": 100, "byte_count": 12345}
+```
+
+> We made an HTTP request to an "orders" endpoint that took 1.23,
+> succeeded with a status code of 200, and returned a body with 12345
+> bytes containing 100 records.
+
+#### Example 2
+
+```
+INFO STATS: {"source": "orders", "status": "failed", "http_status_code": 400, "duration": 1.23}
+```
+
+> We made an HTTP request to an "orders" endpoint that took 1.23 seconds
+> and failed with a status code of 400.
+
+#### Example 3
+
+```
+INFO STATS: {"source": "orders", "status": "running", "duration": 1.2, "record_count": 100}
+INFO STATS: {"source": "orders", "status": "running", "duration": 0.9, "record_count": 100}
+INFO STATS: {"source": "orders", "status": "running", "duration": 2.3, "record_count": 100}
+INFO STATS: {"source": "orders", "status": "succeeded", "duration": 0.1, "record_count": 14}
+```
+
+We fetched a total of 314 records from an "orders" endpoint in 4.5 seconds.
+
+#### Example 4:
+
+```
+INFO STATS: {"source": "orders", "status": "succeeded", "http_status_code": 200, "duration": 1.23}
+```
+
+> We made an HTTP request that succeeded and returned an unspecified
+> number of records.


### PR DESCRIPTION
I've been adding experimental metrics logging to singer-python and a few taps. I'd like to add a best practice recommendation for logging metrics from Taps. I would really appreciate feedback on this best practice recommendation and the singer-python changes. Below are links to diffs for a few taps that use the new singer-python stats utilities, so you can see how the implementation would work in practice.

* Updated Best Practices guide: https://github.com/singer-io/getting-started/blob/metrics/BEST_PRACTICES.md (look at that rather than the diff)
* singer-python - https://github.com/singer-io/singer-python/pull/19
* tap-shippo - https://github.com/singer-io/tap-shippo/pull/3/files
* tap-facebook - https://github.com/singer-io/tap-facebook/pull/3/files
* tap-closeio - https://github.com/singer-io/tap-closeio/pull/6/files

I'm particularly interested in answering feedback in the following areas:

* What terminology should we use? "stats"? "metrics"?
* Are the field names clear?
* For the singer-python change, is the distinction between a Counter and a Timer clear enough?