### PR TITLE
Add legacy field selection info and properties.json info

### DIFF
--- a/docs/DISCOVERY_MODE.md
+++ b/docs/DISCOVERY_MODE.md
@@ -11,6 +11,8 @@ Discovery is typically run with the output redirected to a file so it can be pas
 tap --config CONFIG --discover > catalog.json
 ```
 
+Note that some legacy taps use `properties.json` as the catalog.
+
 ## Schemas
 JSON is used to represent data because it is ubiquitous, readable, and especially appropriate for the large universe of sources that expose data as JSON like web APIs. However, JSON is far from perfect:
 

--- a/docs/RUNNING_AND_DEVELOPING.md
+++ b/docs/RUNNING_AND_DEVELOPING.md
@@ -7,46 +7,46 @@ To run Singer with Python, first make sure Python 3 is installed on your system 
 We recommend installing each Tap and Target in a separate Python virtual environment.  This will insure that you won't have conflicting dependencies between any Taps and Targets.  
 
 ### Running a Singer Tap
-1. Create and activate a Python 3 virtual environment for the Tap, which we'll call `tap-foo`:
+1. Create and activate a Python 3 virtual environment for the Tap, which we'll call `tap-foo`.  When you run this yourself, change the tap name in the angle brackets `< >`
 ```bash
-python3 -m venv ~/.virtualenvs/tap-foo
-source ~/.virtualenvs/tap-foo/bin/activate
+python3 -m venv ~/.virtualenvs/<tap-foo>
+source ~/.virtualenvs/<tap-foo>/bin/activate
 ```
 2. Install the Tap using pip:
 ```bash
-pip install tap-foo
+pip install <tap-foo>
 ```
 3. Edit the Tap's [config file](CONFIG_AND_STATE.md#config-file) (tap_config.json) to include any necessary credentials or parameters.
 
 4. If the tap supports [discovery mode](DISCOVERY_MODE.md), run it to obtain the catalog:
 ```bash
-~/.virtualenvs/tap-foo/bin/tap-foo --config tap_config.json --discover > catalog.json
+~/.virtualenvs/<tap-foo>/bin/<tap-foo> --config tap_config.json --discover > catalog.json
 ```
 5. Depending on what features the Tap supports, you may need to add metadata in the catalog for [stream/field selection](SYNC_MODE.md#streamfield-selection) or [replication-method](SYNC_MODE.md#replication-method).  
 
 6. Run the Tap in sync mode:
 ```bash
-~/.virtualenvs/tap-foo/bin/tap-foo --config tap_config.json --catalog catalog.json
+~/.virtualenvs/<tap-foo>/bin/<tap-foo> --config tap_config.json --catalog catalog.json
 ``` 
 The output should consist of [SCHEMA](SPEC.md#schema-message), [RECORD](SPEC.md#record-message), [STATE](SPEC.md#state-message), and [METRIC](SYNC_MODE.md#metric-messages) messages.  
 
 ### Running a Singer Tap with a Singer Target
-To run a Singer Tap with a Singer Target, follow steps 1-5 above to set up the Tap, and then continue with the following steps. 
+To run a Singer Tap with a Singer Target, follow steps 1-5 above to set up the Tap, and then continue with the following steps.
 
-1. reate and activate a Python 3 virtual environment for the Target, which we'll call `target-bar`:
+1. reate and activate a Python 3 virtual environment for the Target, which we'll call `target-bar`.  Again, when you run this yourself, change the target name in the angle brackets `< >`
 ```bash
-python3 -m venv ~/.virtualenvs/target-bar
-source ~/.virtualenvs/target-bar/bin/activate
+python3 -m venv ~/.virtualenvs/<target-bar>
+source ~/.virtualenvs/<target-bar>/bin/activate
 ```
 2. Install the Target in its virtual environment using pip:
 ```bash
-pip install target-bar
+pip install <target-bar>
 ```
 3. Edit the Target's config file (target_config.json) to include any necessary credentials or parameters.
 
 4. Run the Singer Tap and pipe the output to the Singer Target:
 ```bash
-~/.virtualenvs/tap-foo/bin/tap-foo --config tap_config.json --catalog catalog.json | ~/.virtualenvs/target-bar/bin/target-bar --config target_config.json
+~/.virtualenvs/<tap-foo>/bin/<tap-foo> --config tap_config.json --catalog catalog.json | ~/.virtualenvs/<target-bar>/bin/<target-bar> --config target_config.json
 ```
 
 ### Example - Using Singer to populate Google Sheets

--- a/docs/SYNC_MODE.md
+++ b/docs/SYNC_MODE.md
@@ -16,6 +16,8 @@ like, for example, the point where it left off.
 - `CATALOG` is an optional argument pointing to a JSON file that the
 Tap can use to filter which streams should be synced.
 
+Note: Some legacy taps use `--propertes PROPERTIES` instead of `--catalog CATALOG` where `PROPERTIES` points to the catalog.
+
 ## Streams
 The [Catalog](DISCOVERY_MODE.md#the-catalog) provided to the Tap contains the streams that are available to sync.  Each stream's [metadata](DISCOVERY_MODE.md#metadata) contains information that can be used to control sync behavior.
 
@@ -28,13 +30,58 @@ Taps can support two replication methods, and should decide which to use by chec
 
 
 ## Stream/Field Selection
-Taps should allow users to choose which streams and fields to replicate.  The following metadata should be checked to decide whether a stream/field should be replicated:
+Taps should allow users to choose which streams and fields to replicate. The following metadata should be checked to decide whether a stream/field should be replicated:
 
 | Metadata Keyword | Description  | 
 | ----------------- | ------- |
 | `inclusion` | Only applies to fields.  If this is set to `automatic`, the field should be replicated.  If this is set to `unsupported`, the field should not be replicated.  Can be written by a tap during discovery |
 | `selected` | If this is set to `True`, the stream (empty breadcrumb), or field should be replicated.  If `False`, the stream or field should be omitted.  This metadata is written by services outside the tap. |
 | `selected-by-default` | Only applies to fields.  If there is no `selected` metadata for a  field, this can be set to `True` or `False` to set a default behavior. Can be written by a tap during discovery |
+
+### Legacy Stream/Field Selection
+Some legacy Taps handle stream and field selection by looking for `"selected": true` directly in the stream's schema (or properties.json).
+
+#### Example of legacy Stream/Field Selection
+Here is an example catalog with a selected stream that has two fields selected and one field unselected
+```json
+{
+  "streams": [
+    {
+      "tap_stream_id": "users",
+      "stream": "users",
+      "schema": {
+        "type": ["null", "object"],
+        "selected": true,
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "selected": true,
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "selected": false,
+          },
+          "date_modified": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time",
+            "selected": true,
+          }
+        }
+      }
+    }
+  ]
+}
+```
 
 ## Metric Messages
 A Tap should periodically emit structured log messages containing metrics about read operations. Consumers of the tap logs can parse these metrics out of the logs for monitoring or analysis.


### PR DESCRIPTION
There was some confusion in the Singer slack about Taps that use `properties.json` instead of `catalog.json`, and how to to field selection for Taps that add `"selected": true` to the schema instead of using metadata.

This PR adds notes about both of these items