### PR TITLE
Indicate that pytz is the accepted option for tz

### DIFF
--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -36,8 +36,9 @@ Good:
 Bad:
  - 2017-01-01 00:00:00
 
-When parsing datetimes or converting between timezones, the library accepted for use by singer
-taps is `pytz`. This project has more accurate timezone data than the builtin datetime.timezone.
+When parsing datetimes or converting between timezones, the library
+accepted for use by singer taps is `pytz`. This project has more accurate
+timezone data than the builtin datetime.timezone.
 
 ## Logging and Exception Handling
 

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -36,6 +36,7 @@ Good:
 Bad:
  - 2017-01-01 00:00:00
 
+When parsing datetimes or converting between timezones, the library accepted for use by singer taps is pytz. This project has more accurate timezone data than the builtin datetime.timezone.
 
 ## Logging and Exception Handling
 

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -36,7 +36,8 @@ Good:
 Bad:
  - 2017-01-01 00:00:00
 
-When parsing datetimes or converting between timezones, the library accepted for use by singer taps is pytz. This project has more accurate timezone data than the builtin datetime.timezone.
+When parsing datetimes or converting between timezones, the library accepted for use by singer
+taps is `pytz`. This project has more accurate timezone data than the builtin datetime.timezone.
 
 ## Logging and Exception Handling
 


### PR DESCRIPTION
@timvisher Here's the documentation patch for using pytz as the canonical representation of timezones in Singer taps.