### PR TITLE
add content about how to update config file in spec

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -41,6 +41,11 @@ the API or data source. The format of the configuration will vary by Tap,
 but it must be JSON-encoded and the root of the configuration must be an
 object.
 
+For taps where the credentials need to be refreshed before or during a
+run, the tap can write changes to the config file, and the changes will be
+saved and picked up on subsequent runs. The singer-python method
+`update_config_file()` can be used to make the necessary changes.
+
 See the [Config File](CONFIG_AND_STATE.md#config-file) section for more
 information.
 


### PR DESCRIPTION
There are taps that need to refresh their credentials during or before a run. These credentials are sometimes refreshed in a linked-list fashion, where the previous creds are needed to get the new, refreshed creds. The tap needs a way to update the config file to remember the most recent creds it used.

This PR adds details to the spec about how taps should update the config file.