### PR TITLE
Install git and then checkout code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,12 @@ jobs:
     docker:
       - image: ubuntu:16.04
     steps:
-      - checkout
       - run:
           name: 'Setup environment'
           command: |
             apt update
-            apt install --yes make
+            apt install --yes make git
+      - checkout
       - run:
           name: 'Tests'
           command: |


### PR DESCRIPTION
Here's the error I saw:
```
Either git or ssh (required by git to clone through SSH) is not installed
in the image. Falling back to CircleCI's native git client but the
behavior may be different from official git. If this is an issue, please
use an image that has official git and ssh installed.

ssh: no key found
```

The first section appeared on the last successful run as well.

I rebuilt the container with SSH, connected, and got 
```
root@400194e20721:~# git
-bash: git: command not found
```

So this PR will install `git` and then checkout the code