### PR TITLE
Add pylint section

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,17 +1,19 @@
 # CONTRIBUTING DOCUMENT
-This is the doc that will outline all requirements for contributors
+This is the doc that will outline all requirements for contributors.
 
 
 Before submitting your tap for review, make sure that you have completed all of the following:
 
-- [stream selection](#stream-selection)
-- [field selection](#field-selection)
-- [correct handling of child streams](#how-to-handle-child-streams)
+- [Implemented stream selection](#stream-selection)
+- [Implemented field selection](#field-selection)
+- [Handled child streams correctly](#how-to-handle-child-streams)
 
 ## Stream Selection
 Iterate over only selected streams.
 The tap can get a list of the selected stream objects by calling `get_selected_streams()` on a singer-python `Catalog` object, as is done here:
  ```
+
+```
 selected_streams = catalog.get_selected_streams(state)
 
 for stream in selected_streams:
@@ -22,6 +24,8 @@ for stream in selected_streams:
 ## Field Selection
 To filter a record's fields using the selected metadata from the catalog, the supported approach is to pass every record through the transformer with a metadata dictionary, as is done here:
  ```
+
+```
 with Transformer() as transformer:
     for rec in stream_object.sync():
         singer.write_record(
@@ -38,6 +42,7 @@ with Transformer() as transformer:
 ## How to handle child streams
 If there are child streams, this means that they rely on some piece of information from a corresponding parent.
 To handle this, the tap must grab parent ids in child stream sync function
+
 (see [here][adroll-streams] in the ClientStream sync method)
 
 <!-- Links -->

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Before submitting your tap for review, make sure that you have completed all of 
 - [field selection](#field-selection)
 - [correct handling of child streams](#how-to-handle-child-streams)
 
-##### Stream Selection
+## Stream Selection
 Iterate over only selected streams.
 The tap can get a list of the selected stream objects by calling `get_selected_streams()` on a singer-python `Catalog` object, as is done here:
  ```
@@ -19,7 +19,7 @@ for stream in selected_streams:
  ```
 (see [here](https://github.com/singer-io/tap-adroll/blob/138fc92dc4fb17c4b9446a3cf998b34b288b3e4a/tap_adroll/discover.py#L38) for an example)
 
-##### Field Selection
+## Field Selection
 To filter a record's fields using the selected metadata from the catalog, the supported approach is to pass every record through the transformer with a metadata dictionary, as is done here:
  ```
 with Transformer() as transformer:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # CONTRIBUTING DOCUMENT
 This is the doc that will outline all requirements for contributors.
 
-Before working on your project, please check that someone else has not already submitted the same project already.
+Before working on your project, please check that someone else has not submitted the same project already.
 The [Singer website][singer-io] and the [Singer Slack][singer-slack] are great resources for this.
 
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -86,8 +86,7 @@ def get_format_values(self): # pylint: disable=no-self-use
 
 [Source][trello-streams]
 
-See the [pylint Block Disables Docs][pylint-docs] for more information and
-more examples
+See the [pylint Block Disables Docs][pylint-docs] for more information and more examples.
 
 
 <!-- Links -->

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,9 @@
 # CONTRIBUTING DOCUMENT
 This is the doc that will outline all requirements for contributors.
 
+Before working on your project, please check that someone else has not already submitted the same project already.
+The [Singer website][singer-io] and the [Singer Slack][singer-slack] are great resources for this.
+
 
 Before submitting your tap for review, make sure that you have completed all of the following:
 
@@ -47,6 +50,8 @@ handle this, the tap must grab parent ids in child stream sync function.
 (see [here][adroll-streams] in the ClientStream sync method)
 
 <!-- Links -->
+[singer-io]: https://www.singer.io/
+[singer-slack]: https://singer-slackin.herokuapp.com/
 [adroll-discovery]: https://github.com/singer-io/tap-adroll/blob/v1.0.0/tap_adroll/discover.py#L38
 [adroll-sync]: https://github.com/singer-io/tap-adroll/blob/v1.0.0/tap_adroll/sync.py#L10
 [adroll-streams]: https://github.com/singer-io/tap-adroll/blob/v1.0.0/tap_adroll/streams.py#L55

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Before submitting your tap for review, make sure that you have completed all of 
 - [Implemented stream selection](#stream-selection)
 - [Implemented field selection](#field-selection)
 - [Handled child streams correctly](#how-to-handle-child-streams)
+- [Run pylint](#pylint)
 
 ## Stream Selection
 Iterate over only selected streams.
@@ -49,9 +50,51 @@ handle this, the tap must grab parent ids in child stream sync function.
 
 (see [here][adroll-streams] in the ClientStream sync method)
 
+## Pylint
+
+Assuming your project has the following structure,
+
+``` shell
+/home/singer/tap-adroll
+├── LICENSE
+├── MANIFEST.in
+├── README.md
+├── setup.py
+├── tap_adroll
+│   ├── schemas
+│   ├── client.py
+│   ├── discover.py
+│   ├── __init__.py
+│   ├── streams.py
+│   └── sync.py
+└── tests
+    └── base.py
+```
+
+you can pass `tap_adroll` to the following command to run `pylint`,
+
+``` shell
+pylint tap_adroll --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments'
+```
+
+We strive to use this as the list of disables. If any other disables are needed, then use `pylint`'s inline syntax,
+
+``` python
+def get_format_values(self): # pylint: disable=no-self-use
+    return []
+```
+
+[Source][trello-streams]
+
+See the [pylint Block Disables Docs][pylint-docs] for more information and
+more examples
+
+
 <!-- Links -->
 [singer-io]: https://www.singer.io/
 [singer-slack]: https://singer-slackin.herokuapp.com/
 [adroll-discovery]: https://github.com/singer-io/tap-adroll/blob/v1.0.0/tap_adroll/discover.py#L38
 [adroll-sync]: https://github.com/singer-io/tap-adroll/blob/v1.0.0/tap_adroll/sync.py#L10
 [adroll-streams]: https://github.com/singer-io/tap-adroll/blob/v1.0.0/tap_adroll/streams.py#L55
+[trello-streams]: https://github.com/singer-io/tap-trello/blob/v1.0.0/tap_trello/streams.py#L187
+[pylint-docs]: http://pylint.pycqa.org/en/latest/user_guide/message-control.html#block-disables

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,7 +17,7 @@ selected_streams = catalog.get_selected_streams(state)
 for stream in selected_streams:
     <sync stream>
  ```
-(see [here](https://github.com/singer-io/tap-adroll/blob/138fc92dc4fb17c4b9446a3cf998b34b288b3e4a/tap_adroll/discover.py#L38) for an example)
+(see [here][adroll-discovery] for an example)
 
 ## Field Selection
 To filter a record's fields using the selected metadata from the catalog, the supported approach is to pass every record through the transformer with a metadata dictionary, as is done here:
@@ -31,10 +31,16 @@ with Transformer() as transformer:
             )
         )
 ```
-(see [here](https://github.com/singer-io/tap-adroll/blob/138fc92dc4fb17c4b9446a3cf998b34b288b3e4a/tap_adroll/sync.py#L10) for an example)
+
+(see [here][adroll-sync] for an example)
 
 
 ## How to handle child streams
 If there are child streams, this means that they rely on some piece of information from a corresponding parent.
 To handle this, the tap must grab parent ids in child stream sync function
-(see [here](https://github.com/singer-io/tap-adroll/blob/138fc92dc4fb17c4b9446a3cf998b34b288b3e4a/tap_adroll/streams.py#L55) in the ClientStream sync method)
+(see [here][adroll-streams] in the ClientStream sync method)
+
+<!-- Links -->
+[adroll-discovery]: https://github.com/singer-io/tap-adroll/blob/v1.0.0/tap_adroll/discover.py#L38
+[adroll-sync]: https://github.com/singer-io/tap-adroll/blob/v1.0.0/tap_adroll/sync.py#L10
+[adroll-streams]: https://github.com/singer-io/tap-adroll/blob/v1.0.0/tap_adroll/streams.py#L55

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,8 +10,9 @@ Before submitting your tap for review, make sure that you have completed all of 
 
 ## Stream Selection
 Iterate over only selected streams.
-The tap can get a list of the selected stream objects by calling `get_selected_streams()` on a singer-python `Catalog` object, as is done here:
- ```
+
+The tap can get a list of the selected stream objects by calling `get_selected_streams()` on a singer-python
+`Catalog` object, as is done here:
 
 ```
 selected_streams = catalog.get_selected_streams(state)
@@ -22,8 +23,8 @@ for stream in selected_streams:
 (see [here][adroll-discovery] for an example)
 
 ## Field Selection
-To filter a record's fields using the selected metadata from the catalog, the supported approach is to pass every record through the transformer with a metadata dictionary, as is done here:
- ```
+To filter a record's fields using the selected metadata from the catalog, the supported approach is to pass every
+record through the transformer with a metadata dictionary, as is done here:
 
 ```
 with Transformer() as transformer:
@@ -40,8 +41,8 @@ with Transformer() as transformer:
 
 
 ## How to handle child streams
-If there are child streams, this means that they rely on some piece of information from a corresponding parent.
-To handle this, the tap must grab parent ids in child stream sync function
+If there are child streams, this means that they rely on some piece of information from a corresponding parent. To
+handle this, the tap must grab parent ids in child stream sync function.
 
 (see [here][adroll-streams] in the ClientStream sync method)
 


### PR DESCRIPTION
This PR:
* Adds the requirement that `pylint` needs to be run
* Adds a line about checking if the proposed tap/target already exists
  * [Inspiration from here](https://gist.github.com/PurpleBooth/b24679402957c63ec426#contributing) on discussing the change before making the change
* Creates a links section so the file is not too ugly
  * [Inspiration from here](https://github.com/atom/atom/blob/master/CONTRIBUTING.md)

My emacs also wraps Markdown files to 80 characters. But I could comfortably bump it to 115 and have a split screen. I think we should pick a number and stick to it. 
* It's probably part of a larger discussion, but I think consistency across our docs - on many levels - is important and style should be one of those levels