### PR TITLE
Rewrite schema guidance

### DIFF
--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -75,16 +75,17 @@ If the schema is static, it should be stored in a `schemas` folder under
 the module directory as JSON files rather than as native dicts in the
 source code.
 
-Please avoid vague schemas:
+When reasonable for the data source, it is preferable to write schemas as
+explicitly as possible. For example:
 
-1. Do not use the empty schema `{}`. An empty schema means the target will
-   be unable to do validation or data type transformation.
+1. Explicitly named fields in object schemas instead of `patternProperties` if they are well defined.
+2. Eplicit types associated with fields instead of `{}` if the data type is consistent and documented.
+3. Specifying `additionalProperties: false` when the tap should fail if extra properties are added.
 
-2. Set `"additionalProperties": false` for all "object" schemas. If you do
-   not specify `"additionalProperties": false`, the target will be unable
-   to do any validation or data type transformation on properties that
-   aren't defined in the schema.
-
+In general, any valid JSON Schema is acceptable, and there are use cases
+that may work best when being more or less strict on validation. Targets
+should handle valid JSON Schemas and provide a best effort to load the
+data in a reasonable format.
 
 ## Code Quality
 

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -87,8 +87,8 @@ explicitly as possible. For example:
 
 In general, any valid JSON Schema is acceptable, and there are use cases
 that may work best when being more or less strict on validation. Targets
-should handle valid JSON Schemas and provide a best effort to load the
-data in a reasonable format.
+should handle valid JSON Schemas and provide a best effort approach to
+load the data in a reasonable format.
 
 ## Code Quality
 

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -93,10 +93,10 @@ load the data in a reasonable format.
 **NOTE:** When modifying an existing schema, use extra caution when
 adding properties such as `additionalProperties: false` or an explicit
 type like `integer`. Schema changes such as this can be backwards
-incompatible. In Singer, we use SemVer to the best of our ability, so
-making the schema more restrictive (unless provable beyond question) will
-result in a major version release that will require all users of the tap
-to take special care when upgrading.
+incompatible. In Singer, we use [SemVer](https://semver.org/) to the best
+of our ability, so making the schema more restrictive (unless provable
+beyond question) will result in a major version release that will require
+all users of the tap to take special care when upgrading.
 
 Naturally, a major version release as a result of a small field addition
 is preferably avoided unless absolutely necessary (for example, if a

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -80,7 +80,7 @@ explicitly as possible. For example:
 
 1. Explicitly named fields in object schemas instead of
    `patternProperties` if they are well defined.
-2. Eplicit types associated with fields instead of `{}` if the data type
+2. Explicit types associated with fields instead of `{}` if the data type
    is consistent and documented.
 3. Specifying `additionalProperties: false` when the tap should fail if
    extra properties are added.

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -78,9 +78,12 @@ source code.
 When reasonable for the data source, it is preferable to write schemas as
 explicitly as possible. For example:
 
-1. Explicitly named fields in object schemas instead of `patternProperties` if they are well defined.
-2. Eplicit types associated with fields instead of `{}` if the data type is consistent and documented.
-3. Specifying `additionalProperties: false` when the tap should fail if extra properties are added.
+1. Explicitly named fields in object schemas instead of
+   `patternProperties` if they are well defined.
+2. Eplicit types associated with fields instead of `{}` if the data type
+   is consistent and documented.
+3. Specifying `additionalProperties: false` when the tap should fail if
+   extra properties are added.
 
 In general, any valid JSON Schema is acceptable, and there are use cases
 that may work best when being more or less strict on validation. Targets

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -90,6 +90,15 @@ that may work best when being more or less strict on validation. Targets
 should handle valid JSON Schemas and provide a best effort approach to
 load the data in a reasonable format.
 
+***NOTE*** When modifying an existing schema, use extra caution when
+adding properties such as `additionalProperties: false` or an explicit
+type like `integer`. Schema changes such as this can either be backwards
+incompatible. In Singer, we use SemVer to the best of our ability, so
+marking fields required or otherwise making the schema more restrictive
+(unless provable beyond question) will will result in a major version
+release that will require all users of the tap to take special care when
+upgrading.
+
 ## Code Quality
 
 We recommend running pylint on your Tap and making sure that you

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -90,14 +90,17 @@ that may work best when being more or less strict on validation. Targets
 should handle valid JSON Schemas and provide a best effort approach to
 load the data in a reasonable format.
 
-***NOTE*** When modifying an existing schema, use extra caution when
+**NOTE:** When modifying an existing schema, use extra caution when
 adding properties such as `additionalProperties: false` or an explicit
-type like `integer`. Schema changes such as this can either be backwards
+type like `integer`. Schema changes such as this can be backwards
 incompatible. In Singer, we use SemVer to the best of our ability, so
-marking fields required or otherwise making the schema more restrictive
-(unless provable beyond question) will will result in a major version
-release that will require all users of the tap to take special care when
-upgrading.
+making the schema more restrictive (unless provable beyond question) will
+result in a major version release that will require all users of the tap
+to take special care when upgrading.
+
+Naturally, a major version release as a result of a small field addition
+is preferably avoided unless absolutely necessary (for example, if a
+REST API changes the primary key's name).
 
 ## Code Quality
 


### PR DESCRIPTION
The schema guidance in BEST_PRACTICES.md is a bit out of date and not always the best choice depending on the data source. This PR intends to clarify this guidance and explicitly state that:

1. Any valid JSON Schema is acceptable.
2. Targets should accept a valid JSON schema along with data and make a good faith effort to load with the information given.