### PR TITLE
fix table name property in Catalog

### DIFF
--- a/docs/DISCOVERY_MODE.md
+++ b/docs/DISCOVERY_MODE.md
@@ -104,7 +104,7 @@ The output of discovery mode should be a list of the data streams a Tap supports
 | `stream`          | string             | required  | The name of the stream.        |
 | `tap_stream_id`   | string             | required  | The unique identifier for the stream. This is allowed to be different from the name of the stream in order to allow for sources that have duplicate stream names. |
 | `schema`          | object             | required  | The JSON schema for the stream.  |
-| `table_name`      | string             | optional  | For a database source, the name of the table. |
+| `table`           | string             | optional  | For a database source, the name of the table. |
 | `metadata`        | array of metadata            | optional  | See metadata below for an explanation |
 
 ### Example


### PR DESCRIPTION
The `table_name` property should be `table`, as per in this source code https://github.com/singer-io/singer-python/blob/0c066de21111d8572425083b4a8792d193c80af1/singer/catalog.py#L21